### PR TITLE
Feature/setup multiple containers per gpu

### DIFF
--- a/nvidia.go
+++ b/nvidia.go
@@ -26,8 +26,7 @@ func id2nvidiaID(id string) string {
 func getEnvItems(devs []string) []string {
 	var nvidiaIds []string 
 	for _, ID := range devs {
-			log.Printf(" getEnvItems[] = ID = %s.", ID)
-			nvidiaIds = append(nvidiaIds, id2nvidiaID(ID))
+		nvidiaIds = append(nvidiaIds, id2nvidiaID(ID))
 	}
 	log.Printf("INFO: getEnvItems(): devs = %s.", strings.Join(devs, ","))
 	log.Printf("INFO: getEnvItems(): nvidiaIds = %s.", strings.Join(nvidiaIds, ","))	
@@ -110,7 +109,6 @@ func watchXIDs(ctx context.Context, devs []*pluginapi.Device, xids chan<- *plugi
 		}
 
 		for _, d := range devs {
-			log.Printf("Check = %s => %s.",d.ID , id2nvidiaID(d.ID))			
 			if id2nvidiaID(d.ID) == *e.UUID {
 				xids <- d
 			}

--- a/nvidia.go
+++ b/nvidia.go
@@ -5,7 +5,7 @@ package main
 import (
 	"log"
 	"strings"
-
+	"strconv"
 	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
 
 	"golang.org/x/net/context"
@@ -18,6 +18,22 @@ func check(err error) {
 	}
 }
 
+func id2nvidiaID(id string) string {
+	nvidiaID := strings.Split(id, "_")[0]
+	return nvidiaID
+}	
+
+func getEnvItems(devs []string) []string {
+	var nvidiaIds []string 
+	for _, ID := range devs {
+			log.Printf(" getEnvItems[] = ID = %s.", ID)
+			nvidiaIds = append(nvidiaIds, id2nvidiaID(ID))
+	}
+	log.Printf("INFO: getEnvItems(): devs = %s.", strings.Join(devs, ","))
+	log.Printf("INFO: getEnvItems(): nvidiaIds = %s.", strings.Join(nvidiaIds, ","))	
+	return nvidiaIds
+}
+
 func getDevices() []*pluginapi.Device {
 	n, err := nvml.GetDeviceCount()
 	check(err)
@@ -26,16 +42,18 @@ func getDevices() []*pluginapi.Device {
 	for i := uint(0); i < n; i++ {
 		d, err := nvml.NewDeviceLite(i)
 		check(err)
-		devs = append(devs, &pluginapi.Device{
-			ID:     d.UUID,
-			Health: pluginapi.Healthy,
-		})
+		log.Printf("NVIDIA Driver Info: UUID = %s, PCI.BusID = %s", d.UUID, d.PCI.BusID)
+		for cnt := int64(0); cnt < int64(containerPerGpu); cnt++ {
+			strId := d.UUID + "_" + strconv.FormatInt(cnt, 10)
+			devs = append(devs, &pluginapi.Device{ ID:     strId, Health: pluginapi.Healthy, })
+		}
 	}
 
 	return devs
 }
 
 func deviceExists(devs []*pluginapi.Device, id string) bool {
+	log.Printf("deviceExists = %s.", id)
 	for _, d := range devs {
 		if d.ID == id {
 			return true
@@ -49,7 +67,9 @@ func watchXIDs(ctx context.Context, devs []*pluginapi.Device, xids chan<- *plugi
 	defer nvml.DeleteEventSet(eventSet)
 
 	for _, d := range devs {
-		err := nvml.RegisterEventForDevice(eventSet, nvml.XidCriticalError, d.ID)
+
+		log.Printf("watchXIDs:RegisterEventForDevice = %s.", d.ID)
+		err := nvml.RegisterEventForDevice(eventSet, nvml.XidCriticalError, id2nvidiaID(d.ID))
 		if err != nil && strings.HasSuffix(err.Error(), "Not Supported") {
 			log.Printf("Warning: %s is too old to support healthchecking: %s. Marking it unhealthy.", d.ID, err)
 
@@ -90,7 +110,8 @@ func watchXIDs(ctx context.Context, devs []*pluginapi.Device, xids chan<- *plugi
 		}
 
 		for _, d := range devs {
-			if d.ID == *e.UUID {
+			log.Printf("Check = %s => %s.",d.ID , id2nvidiaID(d.ID))			
+			if id2nvidiaID(d.ID) == *e.UUID {
 				xids <- d
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	resourceName           = "nvidia.com/gpu"
+	containerPerGpu        = 4
 	serverSock             = pluginapi.DevicePluginPath + "nvidia.sock"
 	envDisableHealthChecks = "DP_DISABLE_HEALTHCHECKS"
 	allHealthChecks        = "xids"
@@ -154,9 +155,10 @@ func (m *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Alloc
 	devs := m.devs
 	responses := pluginapi.AllocateResponse{}
 	for _, req := range reqs.ContainerRequests {
+
 		response := pluginapi.ContainerAllocateResponse{
 			Envs: map[string]string{
-				"NVIDIA_VISIBLE_DEVICES": strings.Join(req.DevicesIDs, ","),
+				"NVIDIA_VISIBLE_DEVICES": strings.Join(getEnvItems(req.DevicesIDs), ","),
 			},
 		}
 


### PR DESCRIPTION
Kubernetes - GPU utilization
Ticket #: MECMOBIL-3
 
Root Cause Analysis: Kubernetes currently doesn't support two containers using the same GPU. 
 
Fix/Implementation: k8s-device-plugin was modified to let multiple containers to use the same GPU 
 
Reviewed By: 

